### PR TITLE
Add radio buttons for the player to select their color

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -32,6 +32,7 @@ class GamesController < ApplicationController
   def create
     @game = Game.new(game_params)
     @game.current_turn = 0
+    @game.black_player_id = current_player.id if @game.white_player_id == 0
 
     respond_to do |format|
       if @game.save
@@ -71,6 +72,6 @@ class GamesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def game_params
-      params.require(:game).permit(:current_turn)
+      params.require(:game).permit(:current_turn, :white_player_id)
     end
 end

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -1,5 +1,10 @@
 <h1>New game</h1>
 
-<%= render 'form' %>
+<%= simple_form_for @game do |f| %>
+  <p>I want to be the...</p>
+  <%= f.collection_radio_buttons :white_player_id, [[current_player.id, 'White Player'] ,[nil, 'Black Player']], :first, :last %>
+  <br/>
+  <%= f.button :submit %>
+<% end %>
 
 <%= link_to 'Back', games_path %>

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= simple_form_for @game do |f| %>
   <p>I want to be the...</p>
-  <%= f.collection_radio_buttons :white_player_id, [[current_player.id, 'White Player'] ,[nil, 'Black Player']], :first, :last %>
+  <%= f.collection_radio_buttons :white_player_id, [[current_player.id, 'White Player'] ,[0, 'Black Player']], :first, :last %>
   <br/>
   <%= f.button :submit %>
 <% end %>

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe GamesController, type: :controller do
       post :create, format: :json, game: { current_turn: 0 }
       expect(Game.count).to eq(count + 1)
     end
+
+    let(:player) { FactoryGirl.create(:player, email: 'blah@blah.com', password: 'SPACECAT') }
+
+    it "should make the current player white if 'white player' is selected" do
+      sign_in player
+      post :create, game: { white_player_id: player.id }
+      game = Game.last
+      expect(game.white_player_id).to eq(player.id)
+    end
+
+    it "should make the current player black if 'black player' is selected" do
+      sign_in player
+      post :create, game: { white_player_id: 0 }
+      game = Game.last
+      expect(game.black_player_id).to eq(player.id)
+    end
   end
 
   describe "games#show action" do


### PR DESCRIPTION
On the view for the "new" action, I added radio buttons where the player can choose to be the "White Player" or the "Black Player." Because we have two separate columns in our database for white_player_id and black_player_id, these buttons correspond to white_player_id. If the player selects "White Player", their user id is stored under white_player_id. If they choose "Black Player," a nil value is stored under white_player_id, though the nil value is converted into a 0 since the data type for white_player_id is an integer. The "create" action checks if the white_player_id is a 0; if so, it stores the current player's id as black_player_id.

Also added two new tests to check the success of a player's selection of "White Player" and "Black Player."