### PR TITLE
Add valid_move? to piece superclass and king subclass

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -8,18 +8,12 @@ class Game < ActiveRecord::Base
   has_many :pieces
   has_many :players
 
-  def piece_present?(x, y)
-    if self.pieces.where(x_position: x, y_position: y).any?
-      return true
-    else
-      return false
-    end
+  def is_piece_present?(x, y)
+    self.pieces.where(x_position: x, y_position: y).any?
   end
 
   def get_piece(x, y)
-    if self.piece_present?(x, y)
-      return self.pieces.where(x_position: x, y_position: y).take
-    end
+    self.pieces.where(x_position: x, y_position: y).take
   end
   
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,5 +7,19 @@ class Game < ActiveRecord::Base
   
   has_many :pieces
   has_many :players
+
+  def piece_present?(x, y)
+    if self.pieces.where(x_position: x, y_position: y).any?
+      return true
+    else
+      return false
+    end
+  end
+
+  def get_piece(x, y)
+    if self.piece_present?(x, y)
+      return self.pieces.where(x_position: x, y_position: y).take
+    end
+  end
   
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,2 +1,12 @@
 class King < Piece
+
+  def valid_move?(destination_x, destination_y)
+    super
+    if (destination_x - self.x_position).abs > 1 || (destination_y - self.y_position).abs > 1
+      return false
+    else
+      return true
+    end
+  end
+
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,12 +1,13 @@
 class King < Piece
 
   def valid_move?(destination_x, destination_y)
-    super
-    if (destination_x - self.x_position).abs > 1 || (destination_y - self.y_position).abs > 1
-      return false
-    else
-      return true
+    valid = super(destination_x, destination_y)
+    if valid
+      if (destination_x - self.x_position).abs > 1 || (destination_y - self.y_position).abs > 1
+        valid = false
+      end
     end
+    return valid
   end
 
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -2,6 +2,36 @@ class Piece < ActiveRecord::Base
   belongs_to :game
   belongs_to :player
 
+  def valid_move?(destination_x, destination_y)
+    game = self.get_game
+    # Check if piece is obstructed
+    if self.is_obstructed?(destination_x, destination_y) == true
+      return false
+    # Check if destination is occupied by a piece of the same color
+    elsif game.piece_present?(destination_x, destination_y) == true
+      other_piece = game.get_piece(destination_x, destination_y)
+      if self.get_color == other_piece.get_color
+        return false
+      end
+    end
+    true
+  end
+
+  def get_color
+    game = self.get_game
+    if self.player_id = game.white_player_id
+      return "white"
+    elsif self.player_id = game.black_player_id
+      return "black"
+    else
+      return false
+    end
+  end
+
+  def get_game
+    return Game.find(self.game_id)
+  end
+
   def is_obstructed?(destination_x, destination_y)
     location_x = self.x_position
     location_y = self.y_position

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -2,29 +2,31 @@ class Piece < ActiveRecord::Base
   belongs_to :game
   belongs_to :player
 
+  WHITE = "white"
+  BLACK = "black"
+
   def valid_move?(destination_x, destination_y)
+    valid = true
     game = self.get_game
     # Check if piece is obstructed
-    if self.is_obstructed?(destination_x, destination_y) == true
-      return false
+    if self.is_obstructed?(destination_x, destination_y)
+      valid = false
     # Check if destination is occupied by a piece of the same color
-    elsif game.piece_present?(destination_x, destination_y) == true
+    elsif game.is_piece_present?(destination_x, destination_y)
       other_piece = game.get_piece(destination_x, destination_y)
       if self.get_color == other_piece.get_color
-        return false
+        valid = false
       end
     end
-    true
+    return valid
   end
 
   def get_color
     game = self.get_game
     if self.player_id = game.white_player_id
-      return "white"
+      return WHITE
     elsif self.player_id = game.black_player_id
-      return "black"
-    else
-      return false
+      return BLACK
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161118012333) do
+ActiveRecord::Schema.define(version: 20161115154942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161115154942) do
+ActiveRecord::Schema.define(version: 20161118012333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,10 +6,12 @@ FactoryGirl.define do
   factory :piece do
     association :game
     association :player
+  end
 
-    factory :pawn do
-      type 'Pawn'
-    end
+  factory :pawn do
+  end
+
+  factory :king do
   end
 
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,12 +6,16 @@ FactoryGirl.define do
   factory :piece do
     association :game
     association :player
+    x_position 4
+    y_position 4
   end
 
   factory :pawn do
   end
 
   factory :king do
+    x_position 4
+    y_position 4
   end
 
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Piece, type: :model do
 
   describe "King#valid_move?" do
 
-    let(:king) { FactoryGirl.create(:king, x_position: 4, y_position: 4, game_id: game.id, player_id: black_player.id) }
+    let(:king) { FactoryGirl.create(:king, game_id: game.id, player_id: black_player.id) }
     
     subject { king.valid_move?(destination_x, destination_y) }
 
@@ -26,6 +26,15 @@ RSpec.describe Piece, type: :model do
       let(:destination_y) { 7 }
 
       it "should return false if the king tries to move too far" do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context "no move" do
+      let(:destination_x) { 4 }
+      let(:destination_y) { 4 }
+
+      it "should return false if the king tries to move on top of itself" do
         expect(subject).to eq(false)
       end
     end
@@ -51,7 +60,7 @@ RSpec.describe Piece, type: :model do
 
   describe "Piece#valid_move?" do
 
-    let(:piece) { FactoryGirl.create(:piece, x_position: 4, y_position: 4, game_id: game.id, player_id: white_player.id) }
+    let(:piece) { FactoryGirl.create(:piece, game_id: game.id, player_id: white_player.id) }
 
     subject { piece.valid_move?(7, 4) }
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -5,18 +5,75 @@ RSpec.describe Piece, type: :model do
   let(:white_player) { FactoryGirl.create(:player, email: 'blah@blah.com', password: 'SPACECAT') }
   let(:black_player) { FactoryGirl.create(:player, email: 'meow@meow.com', password: 'MONORAILCAT') }
   let(:game) { FactoryGirl.create(:game, white_player_id: white_player.id, black_player_id: black_player.id) }
-  let(:piece) { FactoryGirl.create(:piece, x_position: 4, y_position: 4, game_id: game.id, player_id: white_player.id) }
 
-  let(:pawn) { FactoryGirl.create(:pawn, x_position: 2, y_position: 1, game_id: game.id, player_id: black_player.id) }
+  describe "King#valid_move?" do
+
+    let(:king) { FactoryGirl.create(:king, x_position: 4, y_position: 4, game_id: game.id, player_id: black_player.id) }
+    
+    subject { king.valid_move?(destination_x, destination_y) }
+
+    context "valid move" do
+      let(:destination_x) { 5 }
+      let(:destination_y) { 5 }
+
+      it "should return true if the move is valid" do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "invalid move" do
+      let(:destination_x) { 7 }
+      let(:destination_y) { 7 }
+
+      it "should return false if the king tries to move too far" do
+        expect(subject).to eq(false)
+      end
+    end
+
+  end
+
+  describe 'a King' do
+    it 'should be a King' do
+      king = FactoryGirl.create(:king, player_id: black_player.id)
+      expect(king.type).to eq 'King'
+    end
+  end
 
   describe 'a Pawn' do
+
+    let(:pawn) { FactoryGirl.create(:pawn, x_position: 2, y_position: 1, game_id: game.id, player_id: black_player.id) }
+
     it 'should be a pawn' do
       pawn = FactoryGirl.create(:pawn, player_id: black_player.id)
       expect(pawn.type).to eq 'Pawn'
     end
   end
 
+  describe "Piece#valid_move?" do
+
+    let(:piece) { FactoryGirl.create(:piece, x_position: 4, y_position: 4, game_id: game.id, player_id: white_player.id) }
+
+    subject { piece.valid_move?(7, 4) }
+
+    it "should return true if the piece is not obstructed" do
+      expect(subject).to eq(true)
+    end
+
+    it "should return false if the piece is obstructed" do
+      FactoryGirl.create(:piece, x_position: 6, y_position: 4, game_id: game.id, player_id: black_player.id)
+      expect(subject).to eq(false)
+    end
+
+    it "should return false if a piece of the same color is occupying the destination" do
+      FactoryGirl.create(:piece, x_position: 7, y_position: 4, game_id: game.id, player_id: white_player.id)
+      expect(subject).to eq(false)
+    end
+
+  end
+
   describe "Piece#is_obstructed?" do
+
+    let(:piece) { FactoryGirl.create(:piece, x_position: 4, y_position: 4, game_id: game.id, player_id: white_player.id) }
 
     subject { piece.is_obstructed?(destination_x, destination_y) }
 


### PR DESCRIPTION
- In piece.rb, I added a valid_move? method that checks if a piece is obstructed or if there is a piece of the same color in the destination square. It calls the is_obstructed? method which I wrote previously and also uses two new methods, get_color and get_game.

- In king.rb, I added a valid_move? submethod that inherits from the superclass and checks to make sure that the king isn't moving more than one square away.

- In piece_spec.rb, I refactored some of the code (there were a lot of rogue pieces running around that could interfere with future tests, so I put them in their proper context). I wrote two tests to check for a king's valid move and invalid move and three tests to check for a piece's valid move in general (expecting 'false' if it was obstructed or if there was a piece of the same color at the destination, and 'true' if there was no obstruction).

- In factories.rb, I took the pawn and the king out of the 'piece' block because they aren't recognized as pawns and kings, respectively, if they're placed there.

Let me know if there's any logic I should add and test for, or anything I forgot to consider!