### PR TITLE
Fix devise testhelpers

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,5 +61,5 @@ RSpec.configure do |config|
   OmniAuth.config.test_mode = true
   
   # Include Devise TestHelpers
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end


### PR DESCRIPTION
This Test helper is deprecated - updated rails_helper.rb with the change.
```
DEPRECATION WARNING:           [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
          For controller tests, please include `Devise::Test::ControllerHelpers` instead.
 (called from <top (required)> at /vagrant/src/chess/spec/controllers/games_controller_spec.rb:3)
DEPRECATION WARNING:           [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
          For controller tests, please include `Devise::Test::ControllerHelpers` instead.
 (called from <top (required)> at /vagrant/src/chess/spec/controllers/omniauth_callbacks_controller_spec.rb:3)
DEPRECATION WARNING:           [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
          For controller tests, please include `Devise::Test::ControllerHelpers` instead.
 (called from <top (required)> at /vagrant/src/chess/spec/controllers/players_controller_spec.rb:3
```