### PR TITLE
Only populate the board if it's not the testing environment

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -2,7 +2,11 @@ class Game < ActiveRecord::Base
   
   scope :is_available, -> { where("black_player_id is null or white_player_id = 0") }
   
-  after_create :populate_board!
+  after_create do
+    unless rails.environment.test?
+      populate_board!
+    end
+  end
   
   def populate_board!
     # black_player_id


### PR DESCRIPTION
Testing is going to be a little slow and difficult since the board is automatically populated after a game is created. This fix makes the board only populated if we're NOT in the testing environment, so we can move our pieces around wherever! (especially nice for pieces that can travel a long way, like the bishop, rook, or queen)