### PR TITLE
Show actual email address of host on game index page

### DIFF
--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -11,7 +11,11 @@
     <li class="game_li col-xs-12">
       <div class="game_info col-xs-10">
         <p class="game_num">Game #<%= game.id %></p>
-        <p class="game_name"><%= game.name%> hosted by test@test.com.</p>
+        <p class="game_name"><%= game.name%> hosted by
+          <%= game.white_player_id == 0 ?
+            Player.where(id: game.black_player_id).take.email : 
+            Player.where(id: game.white_player_id).take.email %>      
+        </p>
       </div>
       <%= link_to 'Join', add_player_game_path(game.id), class: "join_game col-xs-2 btn btn-primary", method: :patch %>
     </li>


### PR DESCRIPTION
Instead of showing "test@test.com", this modification will show the game host's actual email address on the game index page (whether they have chosen to be the black or white player).