### PR TITLE
Update piece ids when an opponent joins the game

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,6 +1,6 @@
 class Game < ActiveRecord::Base
   
-  scope :is_available, -> { where("black_player_id is null or white_player_id = 0") }
+  scope :is_available, -> { where("black_player_id = 0 or white_player_id = 0") }
   has_many :timers
   after_create :populate_board!
   

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -21,12 +21,15 @@ class Player < ActiveRecord::Base
       player.password = Devise.friendly_token[0,20]
     end
   end
-  
+
   def join_game!(game)
     if game.white_player_id == 0
       game.update_attributes(:white_player_id => id)
     else
       game.update_attributes(:black_player_id => id)
+    end
+    game.pieces.each do |piece|
+      piece.update_attributes(:player_id => id) if piece.player_id == 0
     end
   end
 

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -60,4 +60,25 @@ RSpec.describe Player, type: :model do
     end
   end
 
+  describe "player.join_game!" do
+
+    context "updating the pieces" do
+
+      let(:white_player) { FactoryGirl.create(:player, email: 'blah@blah.com', password: 'SPACECAT') }
+      let(:black_player) { FactoryGirl.create(:player, email: 'meow@meow.com', password: 'MONORAILCAT') }
+      let(:game) { FactoryGirl.create(:game, :populated, white_player_id: white_player.id, black_player_id: 0) }
+
+      it "should initially assign the opponent's pieces to be zero" do
+        expect(game.pieces.where(type: 'King').first.player_id).to eq(0)
+      end
+
+      it "should update the pieces with the opponent's id when another player joins" do
+        black_player.join_game!(game)
+        game.reload
+        expect(game.pieces.where(type: 'King').first.player_id).to eq(black_player.id)
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
- Set game.black_player_id to 0 if the starting player chose to be white.
- Updated is_available scope to reflect this change.
- Updated piece ids with the opponent's id in the join_game! method.
- Added tests to verify that the opponent's piece ids were 0 before another player joined and then took the opponent id afterwards.